### PR TITLE
Add option to disable the ESC quit hotkey

### DIFF
--- a/assets/config.toml
+++ b/assets/config.toml
@@ -16,3 +16,4 @@ border = { h = 0.0, s = 0.0, l = 0.31, a = 1.0 }
 [general]
 show_tray = true
 enable_left_cmd = false
+disable_quit = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,12 +10,14 @@ use std::path::{Path, PathBuf};
 pub struct GeneralConfig {
     pub show_tray: Option<bool>,
     pub enable_left_cmd: Option<bool>,
+    pub disable_quit: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]
 pub struct General {
     pub show_tray: bool,
     pub enable_left_cmd: bool,
+    pub disable_quit: bool,
 }
 
 impl Default for General {
@@ -23,6 +25,7 @@ impl Default for General {
         Self {
             show_tray: true,
             enable_left_cmd: false,
+            disable_quit: false,
         }
     }
 }
@@ -92,6 +95,7 @@ impl Config {
             general: General {
                 show_tray: config.general.show_tray.map_or(default_general.show_tray, Into::into),
                 enable_left_cmd: config.general.enable_left_cmd.map_or(default_general.enable_left_cmd, Into::into),
+                disable_quit: config.general.disable_quit.map_or(default_general.disable_quit, Into::into),
             },
         }
     }

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -110,15 +110,19 @@ impl Global for Hotkey {}
 struct EventHandler {
     tx: UnboundedSender<EventType>,
     enable_left_cmd: bool,
+    disable_quit: bool,
 }
 
 impl EventHandler {
     fn new(cx: &mut App) -> Self {
         let tx = cx.global::<Commander>().tx.clone();
         let config = cx.global::<Config>();
-        let enable_left_cmd = config.general.enable_left_cmd;
 
-        Self { tx, enable_left_cmd }
+        Self {
+            tx,
+            enable_left_cmd: config.general.enable_left_cmd,
+            disable_quit: config.general.disable_quit,
+        }
     }
 
     fn handle_flags_changed(&self, keycode: i64, flags: CGEventFlags) -> Option<HotkeyEvent> {
@@ -166,7 +170,7 @@ impl EventHandler {
         flags.remove(CGEventFlags::CGEventFlagCommand);
 
         match Key::from(keycode) {
-            Key::Escape => {
+            Key::Escape if !self.disable_quit => {
                 Some((HotkeyEvent::QuitApplication, true))
             },
             Key::Space => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,12 +7,12 @@ use input::{SearchQuery, TextInput};
 use prelude::FluentBuilder;
 use macos_accessibility_client::accessibility::application_is_trusted_with_prompt;
 
-use crate::{applications::Applications, theme::Theme, ui::list::List};
+use crate::{applications::Applications, config::Config, theme::Theme, ui::list::List};
 
 pub struct Container {
     pub input: Entity<TextInput>,
     pub list: Entity<List>,
-    pub trusted: bool
+    pub trusted: bool,
 }
 
 pub static LIST_ITEM_HEIGHT: f32 = 40.;
@@ -124,6 +124,7 @@ impl Render for Container {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.global::<Theme>();
         let height = self.get_height(cx);
+        let disable_quit = cx.global::<Config>().general.disable_quit;
 
         div()
             .flex()
@@ -158,7 +159,9 @@ impl Render for Container {
                     .border_t_1()
                     .border_color(theme.border)
                     .child(self.render_action_button(theme, "Hide", "␣"))
-                    .child(self.render_action_button(theme, "Quit", "⎋")),
+                    .when(!disable_quit, |cx| {
+                        cx.child(self.render_action_button(theme, "Quit", "⎋"))
+                    })
             )
     }
 }


### PR DESCRIPTION
Hi Gaauwe,

this adds an option called `disable_quit` that disables the quit function accessible with the Escape hotkey by default. For people like me this prevents some frustration: I've repeatedly quit an application instead of closing the switcher. The default is still the old behavior, so not a breaking change.

I've touched formatting as little as possible, though I must say if the project would use `cargo fmt`, that would be easier :)

If you don't like the change, of course no need to merge it - in that case, I'll maintain my fork, no problem. Thanks for open-sourcing your "learning project", it's a great study.

Cheers,
Kevin